### PR TITLE
ujednolicenie nulli

### DIFF
--- a/Ujednolicenie_nulli.ipynb
+++ b/Ujednolicenie_nulli.ipynb
@@ -1,0 +1,828 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "view-in-github",
+        "colab_type": "text"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/PiotrMaciejKowalski/BigData2022-actors/blob/Ujednolicenie_nulli/Ujednolicenie_nulli.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Vzb444kPW31g"
+      },
+      "source": [
+        "#Aktualny setup sparka"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "UxTbMYkeLrk6",
+        "outputId": "e09dc465-9356-4cbb-aacc-c1fcd3c7ca8a"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Looking in indexes: https://pypi.org/simple, https://us-python.pkg.dev/colab-wheels/public/simple/\n",
+            "Collecting pyspark\n",
+            "  Downloading pyspark-3.3.1.tar.gz (281.4 MB)\n",
+            "\u001b[K     |████████████████████████████████| 281.4 MB 40 kB/s \n",
+            "\u001b[?25hCollecting py4j\n",
+            "  Downloading py4j-0.10.9.7-py2.py3-none-any.whl (200 kB)\n",
+            "\u001b[K     |████████████████████████████████| 200 kB 42.0 MB/s \n",
+            "\u001b[?25h  Downloading py4j-0.10.9.5-py2.py3-none-any.whl (199 kB)\n",
+            "\u001b[K     |████████████████████████████████| 199 kB 13.0 MB/s \n",
+            "\u001b[?25hBuilding wheels for collected packages: pyspark\n",
+            "  Building wheel for pyspark (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
+            "  Created wheel for pyspark: filename=pyspark-3.3.1-py2.py3-none-any.whl size=281845512 sha256=596a96500900a7b6b9fa8938ec431d8d60d8c14a32e6a09cf752f004f773317a\n",
+            "  Stored in directory: /root/.cache/pip/wheels/43/dc/11/ec201cd671da62fa9c5cc77078235e40722170ceba231d7598\n",
+            "Successfully built pyspark\n",
+            "Installing collected packages: py4j, pyspark\n",
+            "Successfully installed py4j-0.10.9.5 pyspark-3.3.1\n",
+            "--2022-12-12 19:02:26--  https://dlcdn.apache.org/spark/spark-3.3.1/spark-3.3.1-bin-hadoop2.tgz\n",
+            "Resolving dlcdn.apache.org (dlcdn.apache.org)... 151.101.2.132, 2a04:4e42::644\n",
+            "Connecting to dlcdn.apache.org (dlcdn.apache.org)|151.101.2.132|:443... connected.\n",
+            "HTTP request sent, awaiting response... 200 OK\n",
+            "Length: 274099817 (261M) [application/x-gzip]\n",
+            "Saving to: ‘spark-3.3.1-bin-hadoop2.tgz’\n",
+            "\n",
+            "spark-3.3.1-bin-had 100%[===================>] 261.40M   214MB/s    in 1.2s    \n",
+            "\n",
+            "2022-12-12 19:02:28 (214 MB/s) - ‘spark-3.3.1-bin-hadoop2.tgz’ saved [274099817/274099817]\n",
+            "\n"
+          ]
+        }
+      ],
+      "source": [
+        "!pip install pyspark py4j\n",
+        "!pip install -q findspark\n",
+        "!apt-get install openjdk-8-jdk-headless -qq > /dev/null\n",
+        "!wget https://dlcdn.apache.org/spark/spark-3.3.1/spark-3.3.1-bin-hadoop2.tgz\n",
+        "!tar xf spark-3.3.1-bin-hadoop2.tgz"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {
+        "id": "g_c507iBLsSW"
+      },
+      "outputs": [],
+      "source": [
+        "import pyspark\n",
+        "import findspark\n",
+        "from pyspark.sql import SparkSession\n",
+        "import os\n",
+        "import pyspark.sql.functions as F\n",
+        "import pyspark.sql.types as T\n",
+        "from pyspark.sql.functions import split, col, monotonically_increasing_id, when\n",
+        "from pyspark.sql.types import StructType, StringType, IntegerType, BooleanType, FloatType, TimestampType, DateType, ArrayType, MapType\n",
+        "from typing import List, Tuple, Dict, Any\n",
+        "import numpy"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {
+        "id": "Eiska15v0dHd"
+      },
+      "outputs": [],
+      "source": [
+        "os.environ[\"JAVA_HOME\"] = \"/usr/lib/jvm/java-8-openjdk-amd64\"\n",
+        "os.environ[\"SPARK_HOME\"] = \"/content/spark-3.3.1-bin-hadoop2\""
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 0
+        },
+        "id": "DuZV298G6QU3",
+        "outputId": "8398e5c3-1100-40d3-b839-40865a1fe632"
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "<pyspark.sql.session.SparkSession at 0x7fec37504040>"
+            ],
+            "text/html": [
+              "\n",
+              "            <div>\n",
+              "                <p><b>SparkSession - in-memory</b></p>\n",
+              "                \n",
+              "        <div>\n",
+              "            <p><b>SparkContext</b></p>\n",
+              "\n",
+              "            <p><a href=\"http://2b810bf969cb:4040\">Spark UI</a></p>\n",
+              "\n",
+              "            <dl>\n",
+              "              <dt>Version</dt>\n",
+              "                <dd><code>v3.3.1</code></dd>\n",
+              "              <dt>Master</dt>\n",
+              "                <dd><code>local[*]</code></dd>\n",
+              "              <dt>AppName</dt>\n",
+              "                <dd><code>Colab</code></dd>\n",
+              "            </dl>\n",
+              "        </div>\n",
+              "        \n",
+              "            </div>\n",
+              "        "
+            ]
+          },
+          "metadata": {},
+          "execution_count": 4
+        }
+      ],
+      "source": [
+        "spark=SparkSession.builder.appName('Colab').getOrCreate()\n",
+        "spark"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "p0l3OAblXJ2w"
+      },
+      "source": [
+        "#Pobranie danych"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "kgYZYlTutA0O"
+      },
+      "source": [
+        "##Import danych"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 5,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "SciXhN5JXONa",
+        "outputId": "f5ca9563-31f4-4684-beaa-1d8853238ec7"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "--2022-12-12 19:02:43--  https://datasets.imdbws.com/name.basics.tsv.gz\n",
+            "Resolving datasets.imdbws.com (datasets.imdbws.com)... 99.84.160.94, 99.84.160.101, 99.84.160.41, ...\n",
+            "Connecting to datasets.imdbws.com (datasets.imdbws.com)|99.84.160.94|:443... connected.\n",
+            "HTTP request sent, awaiting response... 200 OK\n",
+            "Length: 237731669 (227M) [binary/octet-stream]\n",
+            "Saving to: ‘name.basics.tsv.gz’\n",
+            "\n",
+            "name.basics.tsv.gz  100%[===================>] 226.72M  71.7MB/s    in 3.2s    \n",
+            "\n",
+            "2022-12-12 19:02:47 (70.3 MB/s) - ‘name.basics.tsv.gz’ saved [237731669/237731669]\n",
+            "\n",
+            "--2022-12-12 19:02:47--  https://datasets.imdbws.com/title.akas.tsv.gz\n",
+            "Resolving datasets.imdbws.com (datasets.imdbws.com)... 99.84.160.94, 99.84.160.101, 99.84.160.41, ...\n",
+            "Connecting to datasets.imdbws.com (datasets.imdbws.com)|99.84.160.94|:443... connected.\n",
+            "HTTP request sent, awaiting response... 200 OK\n",
+            "Length: 290604586 (277M) [binary/octet-stream]\n",
+            "Saving to: ‘title.akas.tsv.gz’\n",
+            "\n",
+            "title.akas.tsv.gz   100%[===================>] 277.14M  88.0MB/s    in 3.1s    \n",
+            "\n",
+            "2022-12-12 19:02:50 (88.0 MB/s) - ‘title.akas.tsv.gz’ saved [290604586/290604586]\n",
+            "\n",
+            "--2022-12-12 19:02:50--  https://datasets.imdbws.com/title.basics.tsv.gz\n",
+            "Resolving datasets.imdbws.com (datasets.imdbws.com)... 99.84.160.94, 99.84.160.101, 99.84.160.41, ...\n",
+            "Connecting to datasets.imdbws.com (datasets.imdbws.com)|99.84.160.94|:443... connected.\n",
+            "HTTP request sent, awaiting response... 200 OK\n",
+            "Length: 165040857 (157M) [binary/octet-stream]\n",
+            "Saving to: ‘title.basics.tsv.gz’\n",
+            "\n",
+            "title.basics.tsv.gz 100%[===================>] 157.39M  63.6MB/s    in 2.5s    \n",
+            "\n",
+            "2022-12-12 19:02:53 (63.6 MB/s) - ‘title.basics.tsv.gz’ saved [165040857/165040857]\n",
+            "\n",
+            "--2022-12-12 19:02:53--  https://datasets.imdbws.com/title.crew.tsv.gz\n",
+            "Resolving datasets.imdbws.com (datasets.imdbws.com)... 99.84.160.94, 99.84.160.101, 99.84.160.41, ...\n",
+            "Connecting to datasets.imdbws.com (datasets.imdbws.com)|99.84.160.94|:443... connected.\n",
+            "HTTP request sent, awaiting response... 200 OK\n",
+            "Length: 63308919 (60M) [binary/octet-stream]\n",
+            "Saving to: ‘title.crew.tsv.gz’\n",
+            "\n",
+            "title.crew.tsv.gz   100%[===================>]  60.38M  59.6MB/s    in 1.0s    \n",
+            "\n",
+            "2022-12-12 19:02:54 (59.6 MB/s) - ‘title.crew.tsv.gz’ saved [63308919/63308919]\n",
+            "\n",
+            "--2022-12-12 19:02:54--  https://datasets.imdbws.com/title.episode.tsv.gz\n",
+            "Resolving datasets.imdbws.com (datasets.imdbws.com)... 99.84.160.94, 99.84.160.101, 99.84.160.41, ...\n",
+            "Connecting to datasets.imdbws.com (datasets.imdbws.com)|99.84.160.94|:443... connected.\n",
+            "HTTP request sent, awaiting response... 200 OK\n",
+            "Length: 38866141 (37M) [binary/octet-stream]\n",
+            "Saving to: ‘title.episode.tsv.gz’\n",
+            "\n",
+            "title.episode.tsv.g 100%[===================>]  37.07M  62.8MB/s    in 0.6s    \n",
+            "\n",
+            "2022-12-12 19:02:55 (62.8 MB/s) - ‘title.episode.tsv.gz’ saved [38866141/38866141]\n",
+            "\n",
+            "--2022-12-12 19:02:55--  https://datasets.imdbws.com/title.principals.tsv.gz\n",
+            "Resolving datasets.imdbws.com (datasets.imdbws.com)... 99.84.160.94, 99.84.160.101, 99.84.160.41, ...\n",
+            "Connecting to datasets.imdbws.com (datasets.imdbws.com)|99.84.160.94|:443... connected.\n",
+            "HTTP request sent, awaiting response... 200 OK\n",
+            "Length: 420278120 (401M) [binary/octet-stream]\n",
+            "Saving to: ‘title.principals.tsv.gz’\n",
+            "\n",
+            "title.principals.ts 100%[===================>] 400.81M  64.2MB/s    in 6.1s    \n",
+            "\n",
+            "2022-12-12 19:03:01 (65.6 MB/s) - ‘title.principals.tsv.gz’ saved [420278120/420278120]\n",
+            "\n",
+            "--2022-12-12 19:03:01--  https://datasets.imdbws.com/title.ratings.tsv.gz\n",
+            "Resolving datasets.imdbws.com (datasets.imdbws.com)... 99.84.160.94, 99.84.160.101, 99.84.160.41, ...\n",
+            "Connecting to datasets.imdbws.com (datasets.imdbws.com)|99.84.160.94|:443... connected.\n",
+            "HTTP request sent, awaiting response... 200 OK\n",
+            "Length: 6309670 (6.0M) [binary/octet-stream]\n",
+            "Saving to: ‘title.ratings.tsv.gz’\n",
+            "\n",
+            "title.ratings.tsv.g 100%[===================>]   6.02M  --.-KB/s    in 0.1s    \n",
+            "\n",
+            "2022-12-12 19:03:01 (48.2 MB/s) - ‘title.ratings.tsv.gz’ saved [6309670/6309670]\n",
+            "\n"
+          ]
+        }
+      ],
+      "source": [
+        "!wget https://datasets.imdbws.com/name.basics.tsv.gz\n",
+        "!wget https://datasets.imdbws.com/title.akas.tsv.gz\n",
+        "!wget https://datasets.imdbws.com/title.basics.tsv.gz\n",
+        "!wget https://datasets.imdbws.com/title.crew.tsv.gz\n",
+        "!wget https://datasets.imdbws.com/title.episode.tsv.gz\n",
+        "!wget https://datasets.imdbws.com/title.principals.tsv.gz\n",
+        "!wget https://datasets.imdbws.com/title.ratings.tsv.gz"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "or9x68JxXc10"
+      },
+      "source": [
+        "##Rozpakowanie danych"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 6,
+      "metadata": {
+        "id": "IpXAjtV4XeKx"
+      },
+      "outputs": [],
+      "source": [
+        "!gzip -dc /content/name.basics.tsv.gz > name.basics.csv\n",
+        "!gzip -dc /content/title.akas.tsv.gz > title.akas.csv\n",
+        "!gzip -dc /content/title.basics.tsv.gz > title.basics.csv\n",
+        "!gzip -dc /content/title.crew.tsv.gz > title.crew.csv\n",
+        "!gzip -dc /content/title.episode.tsv.gz > title.episode.csv\n",
+        "!gzip -dc /content/title.principals.tsv.gz > title.principals.csv\n",
+        "!gzip -dc /content/title.ratings.tsv.gz > title.ratings.csv"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "pPWxy5j_aEvo"
+      },
+      "source": [
+        "#Wczytanie danych"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "tura9f9sGomh"
+      },
+      "source": [
+        "##Ustalenie typów danych"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 7,
+      "metadata": {
+        "id": "CqMSVkG6fFYK"
+      },
+      "outputs": [],
+      "source": [
+        "map_types = {\n",
+        "    str : StringType(),\n",
+        "    int : IntegerType(),\n",
+        "    bool : BooleanType(),\n",
+        "    float: FloatType(),\n",
+        "    'timestamp' : TimestampType(),\n",
+        "    'date' : DateType(),\n",
+        "    List[str] : ArrayType(StringType()),\n",
+        "    Tuple[str] : ArrayType(StringType()),\n",
+        "    Dict[str, str] : MapType(StringType(), StringType())\n",
+        "}"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 8,
+      "metadata": {
+        "id": "WOpkscfjxlf5"
+      },
+      "outputs": [],
+      "source": [
+        "column_conf = {\n",
+        "  'akas'  :  ['titleId','ordering','title','region','language','types','attributes','isOriginalTitle '], \n",
+        "  'title_basics' : ['tconst','titleType','primaryTitle','originalTitle','isAdult','startYear','endYear','runtimeMinutes','genres'],\n",
+        "  'crew' : ['tconst','directors','writers'],\n",
+        "  'episode' : ['tconst','parentTconst','seasonNumber','episodeNumber'],\n",
+        "  'principals' : ['tconst','ordering','nconst','category','job','characters'],\n",
+        "  'ratings' : ['tconst','averageRating','numVotes'],\n",
+        "  'name_basics' : ['nconst','primaryName','birthYear','deathYear','primaryProfession','knownForTitles']\n",
+        "}\n",
+        "column_type_collection = {\n",
+        "    int : ['ordering', 'startYear', 'endYear', 'runtimeMinutes', 'seasonNumber', 'episodeNumber', 'numVotes', 'birthYear', 'deathYear' ],\n",
+        "    str : ['titleId', 'title', 'region', 'language', 'types', 'attributes', 'tconst', 'titleType', 'primaryTitle', 'originalTitle', 'genres', 'directors', 'writers', 'parentTconst', 'category', 'job', 'characters', 'primaryName', 'primaryProfession', 'knownForTitles'],\n",
+        "    bool : ['isOriginalTitle', 'isAdult' ],\n",
+        "    float : ['averageRating']\n",
+        "}"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 9,
+      "metadata": {
+        "id": "5I3YkxQt1MhO"
+      },
+      "outputs": [],
+      "source": [
+        "def init_schema(conf, column_type_collection):\n",
+        "  map = {}\n",
+        "  for pole in conf:\n",
+        "    for python_type, column_list in column_type_collection.items():\n",
+        "      if pole in column_list:\n",
+        "        map[pole] = map_types[python_type]\n",
+        "  schemat= StructType()\n",
+        "  for pole, typ in map.items():\n",
+        "    schemat = schemat.add(pole, typ, True)\n",
+        "  return schemat"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 10,
+      "metadata": {
+        "id": "QfCrAOetypQP"
+      },
+      "outputs": [],
+      "source": [
+        "Schematy=[schemat_title_akas, schemat_title_basics, schemat_title_crew, schemat_title_episode, schemat_title_principals,\n",
+        "schemat_title_ratings, schemat_name_basics] = [ \n",
+        "init_schema(column_conf[table], column_type_collection) \n",
+        "  for table in ('akas', 'title_basics', 'crew', 'episode', 'principals', 'ratings', 'name_basics')]"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "s-hzkKehxgnQ"
+      },
+      "source": [
+        "##Wczytajmy dane z rozpakowanych plików"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 11,
+      "metadata": {
+        "id": "skegmFMQXpcA"
+      },
+      "outputs": [],
+      "source": [
+        "CSV=['title.akas.csv', 'title.basics.csv', 'title.crew.csv','title.episode.csv', 'title.principals.csv',\n",
+        "'title.ratings.csv', 'name.basics.csv']"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 12,
+      "metadata": {
+        "id": "lroZaGhN9ssF"
+      },
+      "outputs": [],
+      "source": [
+        "def upload(schemat, csv):\n",
+        "  df=spark.read.option(\"header\",\"true\").option(\"delimiter\", \"\\t\").schema(schemat).csv(csv)\n",
+        "  return df"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 13,
+      "metadata": {
+        "id": "lvA1h-JA-4gO"
+      },
+      "outputs": [],
+      "source": [
+        "Data=[df_title_akas, df_title_basics, df_title_crew, df_title_episode, df_title_principals,\n",
+        "df_title_ratings, df_name_basics]=[\n",
+        "upload(Schematy[i], CSV[i])\n",
+        "  for i in range(7) \n",
+        "]"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "#Zamiana \"\\\\N\" na null"
+      ],
+      "metadata": {
+        "id": "djz8LQmBCYSi"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "for column in ['primaryProfession', 'knownForTitles']:\n",
+        "  df_name_basics = df_name_basics.withColumn(column, when(df_name_basics[column] == \"\\\\N\", None).otherwise(df_name_basics[column]))\n",
+        "\n",
+        "for column in ['title', 'region', 'language', 'types', 'attributes']:\n",
+        "  df_title_akas = df_title_akas.withColumn(column, when(df_title_akas[column] == \"\\\\N\", None).otherwise(df_title_akas[column]))\n",
+        "\n",
+        "for column in ['titleType', 'primaryTitle', 'originalTitle', 'genres']:\n",
+        "  df_title_basics = df_title_basics.withColumn(column, when(df_title_basics[column] == \"\\\\N\", None).otherwise(df_title_basics[column]))\n",
+        "\n",
+        "for column in ['directors', 'writers']:\n",
+        "  df_title_crew = df_title_crew.withColumn(column, when(df_title_crew[column] == \"\\\\N\", None).otherwise(df_title_crew[column]))\n",
+        "\n",
+        "df_title_episode=df_title_episode.withColumn('parentTconst', when(df_title_episode['parentTconst'] == \"\\\\N\", None).otherwise(df_title_episode['parentTconst']))\n",
+        "\n",
+        "for column in ['ordering', 'category', 'job', 'characters']:\n",
+        "  df_title_principals = df_title_principals.withColumn(column, when(df_title_principals[column] == \"\\\\N\", None).otherwise(df_title_principals[column]))"
+      ],
+      "metadata": {
+        "id": "vbL-ipP5qhCH"
+      },
+      "execution_count": 14,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "1uOGkwaknuQa"
+      },
+      "source": [
+        "#Zamiana string na array(string)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "eZUKeWjuzSl9"
+      },
+      "source": [
+        "Zmienimy następujące kolumny: z tabeli df_title_akas kolumny attributes, types;\n",
+        "z tabeli df_title_basics kolumna genres;\n",
+        "z tabeli df_name_basics kolumny primaryProfession, knownForTitles;\n",
+        "z tabeli df_title_crew kolumny directors, writers.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "_Q7BCwJ2koZv"
+      },
+      "source": [
+        "##Stworzenie nowych, odrębnych kolumn typu array, z kolumn typu string określonych wyżej"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 15,
+      "metadata": {
+        "id": "sUE_PBRC2ng_"
+      },
+      "outputs": [],
+      "source": [
+        "df_title_akas_types= df_title_akas.select(split(col(\"types\"),\",\").alias(\"types\"))\n",
+        "df_title_akas_attributes= df_title_akas.select(split(col(\"attributes\"),\",\").alias(\"attributes\"))\n",
+        "df_name_basics_primaryProfession= df_name_basics.select(split(col(\"primaryProfession\"),\",\").alias(\"primaryProfession\"))\n",
+        "df_name_basics_knownForTitles= df_name_basics.select(split(col(\"knownForTitles\"),\",\").alias(\"knownForTitles\"))\n",
+        "df_title_basics_genres=df_title_basics.select(split(col(\"genres\"),\",\").alias(\"genres\"))\n",
+        "df_title_crew_directors=df_title_crew.select(split(col(\"directors\"),\",\").alias(\"directors\"))\n",
+        "df_title_crew_writers=df_title_crew.select(split(col(\"writers\"),\",\").alias(\"writers\"))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "KT28G6KNrw9P"
+      },
+      "source": [
+        "##Zamieńmy pierwotne kolumny na nowe"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "K_gCEnEWr-mu"
+      },
+      "source": [
+        "###usuńmy pierwotne kolumny z niewłaściwym typem danych"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 16,
+      "metadata": {
+        "id": "tyOoHonZrwNd"
+      },
+      "outputs": [],
+      "source": [
+        "df_title_akas= df_title_akas.drop(\"types\")\n",
+        "df_title_akas= df_title_akas.drop(\"attributes\")\n",
+        "df_name_basics= df_name_basics.drop(\"primaryProfession\")\n",
+        "df_name_basics= df_name_basics.drop(\"knownForTitles\")\n",
+        "df_title_basics=df_title_basics.drop(\"genres\")\n",
+        "df_title_crew=df_title_crew.drop(\"directors\")\n",
+        "df_title_crew=df_title_crew.drop(\"writers\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "sPeY3_PD11bz"
+      },
+      "source": [
+        "###dodajmy kolumny ideksów do nowych (jednokolumnowych) tabel i tabel pierwotnych"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "MIiVP-D23i_H"
+      },
+      "source": [
+        "dodajmy kolumny indeksów do bazowych tabel"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 17,
+      "metadata": {
+        "id": "Gm6ACVCa25_X"
+      },
+      "outputs": [],
+      "source": [
+        "df_title_akas=df_title_akas.select(\"*\").withColumn(\"id\", monotonically_increasing_id())\n",
+        "df_name_basics=df_name_basics.select(\"*\").withColumn(\"id\", monotonically_increasing_id())\n",
+        "df_title_basics=df_title_basics.select(\"*\").withColumn(\"id\", monotonically_increasing_id())\n",
+        "df_title_crew= df_title_crew.select(\"*\").withColumn(\"id\", monotonically_increasing_id())"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "BYp1dfa65ClX"
+      },
+      "source": [
+        "i do nowych, jednokolumnowych tabel"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 18,
+      "metadata": {
+        "id": "er0LGEou4PsO"
+      },
+      "outputs": [],
+      "source": [
+        "df_title_akas_types=df_title_akas_types.select(\"*\").withColumn(\"id1\", monotonically_increasing_id())\n",
+        "df_title_akas_attributes=df_title_akas_attributes.select(\"*\").withColumn(\"id2\", monotonically_increasing_id())\n",
+        "df_name_basics_primaryProfession=df_name_basics_primaryProfession.select(\"*\").withColumn(\"id3\", monotonically_increasing_id())\n",
+        "df_name_basics_knownForTitles=df_name_basics_knownForTitles.select(\"*\").withColumn(\"id4\", monotonically_increasing_id())\n",
+        "df_title_basics_genres=df_title_basics_genres.select(\"*\").withColumn(\"id5\", monotonically_increasing_id())\n",
+        "df_title_crew_directors=df_title_crew_directors.select(\"*\").withColumn(\"id6\", monotonically_increasing_id())\n",
+        "df_title_crew_writers=df_title_crew_writers.select(\"*\").withColumn(\"id7\", monotonically_increasing_id())"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "OYHabuPr5g3u"
+      },
+      "source": [
+        "###połączmy je odpowiednio na bazie numerów indeksu"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 19,
+      "metadata": {
+        "id": "wO3XHuje6aIS"
+      },
+      "outputs": [],
+      "source": [
+        "df_title_akas= df_title_akas.join(df_title_akas_types, col('id') == col('id1'), 'leftouter')\n",
+        "df_title_akas= df_title_akas.join(df_title_akas_attributes, col('id') == col('id2'), 'leftouter')\n",
+        "df_name_basics= df_name_basics.join(df_name_basics_primaryProfession, col('id') == col('id3'), 'leftouter')\n",
+        "df_name_basics= df_name_basics.join(df_name_basics_knownForTitles, col('id') == col('id4'), 'leftouter')\n",
+        "df_title_basics=df_title_basics.join(df_title_basics_genres, col('id') == col('id5'), 'leftouter')\n",
+        "df_title_crew= df_title_crew.join(df_title_crew_directors, col('id') == col('id6'), 'leftouter')\n",
+        "df_title_crew= df_title_crew.join(df_title_crew_writers, col('id') == col('id7'), 'leftouter')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "yDlIC7WZ8Iel"
+      },
+      "source": [
+        "###usuńmy kolumny indeksów"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 20,
+      "metadata": {
+        "id": "nMZn83J18fvq"
+      },
+      "outputs": [],
+      "source": [
+        "df_title_akas=df_title_akas.drop(\"id\").drop(\"id1\").drop(\"id2\")\n",
+        "df_name_basics=df_name_basics.drop(\"id\").drop(\"id3\").drop(\"id4\")\n",
+        "df_title_basics=df_title_basics.drop(\"id\").drop(\"id5\")\n",
+        "df_title_crew=df_title_crew.drop(\"id\").drop(\"id6\").drop(\"id7\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "i49wO8BapbWS"
+      },
+      "source": [
+        "#Usunięcie duplikatów"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 21,
+      "metadata": {
+        "id": "IwhoeuIDphv_"
+      },
+      "outputs": [],
+      "source": [
+        "df_name_basics=df_name_basics.distinct()\n",
+        "df_title_akas=df_title_akas.distinct()\n",
+        "df_title_basics=df_title_basics.distinct()\n",
+        "df_title_crew=df_title_crew.distinct()\n",
+        "df_title_episode=df_title_episode.distinct()\n",
+        "df_title_principals=df_title_principals.distinct()\n",
+        "df_title_ratings=df_title_ratings.distinct()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "9YRXOpTYRFjw"
+      },
+      "source": [
+        "#Wyświetlmy dane"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 22,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "HHXa_0Gq-GHP",
+        "outputId": "85dfce13-8d62-4dc7-e94f-76e2d7c325d3"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "+-----------+---------+---------+-----------------+--------------------+\n",
+            "|primaryName|birthYear|deathYear|primaryProfession|      knownForTitles|\n",
+            "+-----------+---------+---------+-----------------+--------------------+\n",
+            "|  nm0000004|     null|     1949|           [1982]|[actor, soundtrac...|\n",
+            "|  nm0000005|     null|     1918|           [2007]|[writer, director...|\n",
+            "|  nm0000010|     null|     1899|           [1986]|[actor, soundtrac...|\n",
+            "+-----------+---------+---------+-----------------+--------------------+\n",
+            "only showing top 3 rows\n",
+            "\n",
+            "+----------+--------+--------------------+------+--------+----------+----------+\n",
+            "|   titleId|ordering|               title|region|language|     types|attributes|\n",
+            "+----------+--------+--------------------+------+--------+----------+----------+\n",
+            "|tt13428982|       1|         #Widerstand|  null|    null|[original]|      null|\n",
+            "| tt9860130|       1|'Watashi, kawaiku...|  null|    null|[original]|      null|\n",
+            "|tt14091730|       1|50 Years of Mr Me...|  null|    null|[original]|      null|\n",
+            "+----------+--------+--------------------+------+--------+----------+----------+\n",
+            "only showing top 3 rows\n",
+            "\n",
+            "+---------+---------+--------------------+--------------------+-------+---------+-------+--------------+---------------+\n",
+            "|   tconst|titleType|        primaryTitle|       originalTitle|isAdult|startYear|endYear|runtimeMinutes|         genres|\n",
+            "+---------+---------+--------------------+--------------------+-------+---------+-------+--------------+---------------+\n",
+            "|tt0001341|    movie|Jarní sen starého...|Jarní sen starého...|   null|     1913|   null|          null|       [Comedy]|\n",
+            "|tt0002007|    short|Alkali Ike's Boar...|Alkali Ike's Boar...|   null|     1912|   null|          null|[Comedy, Short]|\n",
+            "|tt0005285|    short|The Fable of the ...|The Fable of the ...|   null|     1915|   null|          null|[Comedy, Short]|\n",
+            "+---------+---------+--------------------+--------------------+-------+---------+-------+--------------+---------------+\n",
+            "only showing top 3 rows\n",
+            "\n",
+            "+---------+-----------+-----------+\n",
+            "|   tconst|  directors|    writers|\n",
+            "+---------+-----------+-----------+\n",
+            "|tt0000657|[nm0005717]|       null|\n",
+            "|tt0001799|[nm0029253]|       null|\n",
+            "|tt0003098|[nm0738109]|[nm0200776]|\n",
+            "+---------+-----------+-----------+\n",
+            "only showing top 3 rows\n",
+            "\n",
+            "+---------+------------+------------+-------------+\n",
+            "|   tconst|parentTconst|seasonNumber|episodeNumber|\n",
+            "+---------+------------+------------+-------------+\n",
+            "|tt0043426|   tt0040051|           3|           42|\n",
+            "|tt0043693|   tt0989125|           2|            8|\n",
+            "|tt0045519|   tt0989125|           4|           11|\n",
+            "+---------+------------+------------+-------------+\n",
+            "only showing top 3 rows\n",
+            "\n",
+            "+---------+--------+---------+-------+------------------+\n",
+            "|   tconst|ordering| category|    job|        characters|\n",
+            "+---------+--------+---------+-------+------------------+\n",
+            "|tt0000050|       1|nm3029234|   self|              null|\n",
+            "|tt0000230|       6|nm0674518| writer|story \"Cinderella\"|\n",
+            "|tt0000325|       1|nm0112631|actress|              null|\n",
+            "+---------+--------+---------+-------+------------------+\n",
+            "only showing top 3 rows\n",
+            "\n",
+            "+---------+-------------+--------+\n",
+            "|   tconst|averageRating|numVotes|\n",
+            "+---------+-------------+--------+\n",
+            "|tt0001011|          4.4|      17|\n",
+            "|tt0001015|          4.4|      25|\n",
+            "|tt0001253|          5.6|      23|\n",
+            "+---------+-------------+--------+\n",
+            "only showing top 3 rows\n",
+            "\n"
+          ]
+        }
+      ],
+      "source": [
+        "df_name_basics.show(3)\n",
+        "df_title_akas.show(3)\n",
+        "df_title_basics.show(3)\n",
+        "df_title_crew.show(3)\n",
+        "df_title_episode.show(3)\n",
+        "df_title_principals.show(3)\n",
+        "df_title_ratings.show(3)"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "collapsed_sections": [
+        "Vzb444kPW31g",
+        "p0l3OAblXJ2w",
+        "kgYZYlTutA0O",
+        "pPWxy5j_aEvo",
+        "KT28G6KNrw9P",
+        "i49wO8BapbWS"
+      ],
+      "provenance": [],
+      "include_colab_link": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}


### PR DESCRIPTION
Korzystna była zmiana nulli przed zmianą typu danych na array, poza aktualnym setupem sparka nowa jest jedynie sekcja 'Zamiana "\N" na null'. 
Nie wiem dlaczego nie działała krótsza opcja:
for df in [df_name_basics, df_title_akas, df_title_basics, df_title_crew, df_title_episode, df_title_principals, df_title_ratings]:
  for col in df.columns:
    df = df.withColumn(col, when(df[col] == "\\N", None).otherwise(df[col]))

